### PR TITLE
Improving context for activating-flexibility-tests failure alert

### DIFF
--- a/activating-flexibility-tests/action.yml
+++ b/activating-flexibility-tests/action.yml
@@ -7,6 +7,9 @@ inputs:
   service-name:
     description: 'Name of the Docker image of the service to run the test for'
     required: true
+  branch-name:
+    description: 'Name of the branch from where the test was triggered'
+    required: false
   service-version:
     description: 'Version of the Docker image of the service to run the test for'
     required: true
@@ -37,7 +40,7 @@ runs:
         workflow_file_name: remote-test-trigger.yml
         client_payload: >-
           { 
-            "origin": "${{ inputs.service-name }}", 
+            "origin": "${{ inputs.service-name }}:${{ inputs.branch-name }}", 
             "test-to-trigger": "${{ inputs.test-to-trigger }}", 
             "target-environment": "${{ inputs.target-environment }}", 
             "${{ inputs.service-name }}-version": "${{ inputs.service-version }}" 


### PR DESCRIPTION
In order to know if [the alerts](https://app.slack.com/client/T0AJLCX6E/C054AR3QE9H), are from a release flow or from a feature branch. That way it is more obvious if the failure needs to be investigated or if it is just changes under development. 