### PR TITLE
VK-720 Use service-versions to trigger activating-flexibility-tests

### DIFF
--- a/activating-flexibility-tests/action.yml
+++ b/activating-flexibility-tests/action.yml
@@ -4,15 +4,14 @@ inputs:
   test-to-trigger:
     description: 'Which test to trigger, e.g., system-activation'
     required: true
-  service-name:
-    description: 'Name of the Docker image of the service to run the test for'
-    required: true
   branch-name:
     description: 'Name of the branch from where the test was triggered'
     required: false
-  service-version:
-    description: 'Version of the Docker image of the service to run the test for'
-    required: true
+  service-versions:
+    description: 'Versions of the Docker image of the services to run the test for'
+    type: string
+    default: '{}'
+    required: false
   comment-downstream-url:
     description: 'Downstream url where to the trigger will add a comment with a link to the started workflow'
     required: false
@@ -43,7 +42,7 @@ runs:
             "origin": "${{ inputs.service-name }}:${{ inputs.branch-name }}", 
             "test-to-trigger": "${{ inputs.test-to-trigger }}", 
             "target-environment": "${{ inputs.target-environment }}", 
-            "${{ inputs.service-name }}-version": "${{ inputs.service-version }}" 
+            "service-versions": ${{ toJson(inputs.service-version) }} 
           }
         github_token: ${{ steps.generate-token.outputs.token }}
         comment_downstream_url: ${{ inputs.comment-downstream-url }}

--- a/activating-flexibility-tests/action.yml
+++ b/activating-flexibility-tests/action.yml
@@ -43,7 +43,9 @@ runs:
             "origin": "${{ inputs.service-name }}:${{ inputs.branch-name }}", 
             "test-to-trigger": "${{ inputs.test-to-trigger }}", 
             "target-environment": "${{ inputs.target-environment }}", 
-            "${{ inputs.service-name }}-version": "${{ inputs.service-version }}" 
+            "service-versions" : { 
+                "${{ inputs.service-name }}": "${{ inputs.service-version }}" 
+            }
           }
         github_token: ${{ steps.generate-token.outputs.token }}
         comment_downstream_url: ${{ inputs.comment-downstream-url }}

--- a/activating-flexibility-tests/action.yml
+++ b/activating-flexibility-tests/action.yml
@@ -4,14 +4,15 @@ inputs:
   test-to-trigger:
     description: 'Which test to trigger, e.g., system-activation'
     required: true
+  service-name:
+    description: 'Name of the Docker image of the service to run the test for'
+    required: true
   branch-name:
     description: 'Name of the branch from where the test was triggered'
     required: false
-  service-versions:
-    description: 'Versions of the Docker image of the services to run the test for'
-    type: string
-    default: '{}'
-    required: false
+  service-version:
+    description: 'Version of the Docker image of the service to run the test for'
+    required: true
   comment-downstream-url:
     description: 'Downstream url where to the trigger will add a comment with a link to the started workflow'
     required: false
@@ -42,7 +43,7 @@ runs:
             "origin": "${{ inputs.service-name }}:${{ inputs.branch-name }}", 
             "test-to-trigger": "${{ inputs.test-to-trigger }}", 
             "target-environment": "${{ inputs.target-environment }}", 
-            "service-versions": ${{ toJson(inputs.service-version) }} 
+            "${{ inputs.service-name }}-version": "${{ inputs.service-version }}" 
           }
         github_token: ${{ steps.generate-token.outputs.token }}
         comment_downstream_url: ${{ inputs.comment-downstream-url }}


### PR DESCRIPTION
As part of VK-720 we added an extra parameter to the activating-flexibility-tests ([here](https://github.com/sympower/activating-flexibility-tests/pull/411), and [here](https://github.com/sympower/activating-flexibility-tests/pull/419) for cleaning the name) to be able to receive more versions (we hit the 10 inputs limit on GitHub).

We are now using the new map in place of the old service+version: this means that the repositories that are using [the old version](https://github.com/sympower/msa-pulsar-mqtt-connector/blob/8c8b1770ef5151b0657f0a5ee823da398bcc2f54/.github/workflows/system-test.yml#L24) of this composite action can continue to build with what they have, but we are encouraging the migration to the service-versions map when updating this reference.

Need a feedback from @sympower/flexitarians on this, but cannot add them as reviewers.