### PR TITLE
Inlude origin workflow URL in activating-felxibility-tests trigger

### DIFF
--- a/activating-flexibility-tests/action.yml
+++ b/activating-flexibility-tests/action.yml
@@ -41,6 +41,7 @@ runs:
         client_payload: >-
           { 
             "origin": "${{ inputs.service-name }}:${{ inputs.branch-name }}", 
+            "origin-workflow" : "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
             "test-to-trigger": "${{ inputs.test-to-trigger }}", 
             "target-environment": "${{ inputs.target-environment }}", 
             "service-versions" : "{ \"${{ inputs.service-name }}\": \"${{ inputs.service-version }}\" }"


### PR DESCRIPTION
In order to be able to have a better alert for test failures, #activating-flexibility-tests-alerts.
Currently, one has to find the origin workflow manually. 

I am not sure this will work, or how to test that it will work. 
My thought was just to get it merged and see what happens :crossed_fingers: 