### PR TITLE
CLEAN replace deprecated action name for gradle build

### DIFF
--- a/setup-build-environment/action.yml
+++ b/setup-build-environment/action.yml
@@ -13,7 +13,7 @@ runs:
         fetch-depth: 0
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v3
       with:
         gradle-home-cache-cleanup: true
 


### PR DESCRIPTION
Current action name is deprecated and creates annoying warnings in build report like [here](https://github.com/sympower/msa-bid-customer-notifier/actions/runs/9831355869)