### PR TITLE
TECH-1230: Allow for initial schema publication

### DIFF
--- a/upload-openapi-schema/action.yml
+++ b/upload-openapi-schema/action.yml
@@ -34,7 +34,8 @@ runs:
       shell: bash
       if:
         env.HAS_SCHEMA == 'true'
-        && steps.openapi-files.outputs.any_modified == 'true'
+        # Temp always upload until initial schema versions have been published
+        # && steps.openapi-files.outputs.any_modified == 'true'
       run: |
         set -eu
         


### PR DESCRIPTION
I thought that the first time the changed-files action runs, it will detect the files as changed. But apparently it doesn't work that way. With the current setup, no new artifact will be published until new schema changes occur. Although this is what we want eventually, we still want to publish the existing "initial version" of the schemas  :/ 