### PR TITLE
Re-enable openapi schema upload only on schema changes

### DIFF
--- a/upload-openapi-schema/action.yml
+++ b/upload-openapi-schema/action.yml
@@ -34,8 +34,7 @@ runs:
       shell: bash
       if:
         env.HAS_SCHEMA == 'true'
-        # Temp always upload until initial schema versions have been published
-        # && steps.openapi-files.outputs.any_modified == 'true'
+        && steps.openapi-files.outputs.any_modified == 'true'
       run: |
         set -eu
         


### PR DESCRIPTION
Afaik, all msas with existing schemas have now published them [see](http://nexus.symp/#browse/browse:maven-releases:net%2Fsympower%2Fopenapi-schemas). We should be good to go back to uploading only when these schemas have changed. 