### PR TITLE
Uncomment publish on schema change

### DIFF
--- a/upload-openapi-schema/action.yml
+++ b/upload-openapi-schema/action.yml
@@ -37,9 +37,7 @@ runs:
       shell: bash
       if:
         env.HAS_SCHEMA == 'true'
-#      Temporary disable, otherwise we might wait for a long time for the badge to be updated
-#      since the openapi specs are not updated very frequently
-#        && steps.openapi-files.outputs.any_modified == 'true'
+       && steps.openapi-files.outputs.any_modified == 'true'
       run: |
         set -eu
         
@@ -52,9 +50,7 @@ runs:
     - name: Update Schema Version Badge
       if:
         env.HAS_SCHEMA == 'true'
-#      Temporary disable, otherwise we might wait for a long time for the badge to be updated
-#      since the openapi specs are not updated very frequently
-#        && steps.openapi-files.outputs.any_modified == 'true'
+       && steps.openapi-files.outputs.any_modified == 'true'
       uses: schneegans/dynamic-badges-action@v1.7.0
       with:
         auth: ${{ fromJSON(inputs.secrets).GIST_SECRET }}


### PR DESCRIPTION
# Description
Let's revert the temporary change. If teams adopt the badge in the future, then they can force a minor open schema change (e.g. extra space) or wait until the next schema update, in order for their badge to show up a value.


## Type of change

- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Refactor
- [ ] Documentation update

## Checklist

- [ ] Any new code is covered with unit tests and/or integration tests
- [ ] There were tests that got removed
  - \<reason of removal\> 
- [ ] Manual testing required: yes/no
  - Test plan: [link](https://www.notion.so/sympower)
  - Findings: [link](https://www.notion.so/sympower)