### PR TITLE
Unique versions for test images

### DIFF
--- a/format-version/action.yml
+++ b/format-version/action.yml
@@ -19,7 +19,7 @@ runs:
         
         IS_RELEASE_STYLE='${{ inputs.style-as-release }}'
         
-        dateVersion=currentDate=$(date +"%Y.%m.%d.%H.%M") ;
+        dateVersion=$(date +"%Y.%m.%d.%H.%M") ;
         if [ "$IS_RELEASE_STYLE" = "true" ] ; then
           tag="${dateVersion}" ;
           echo "version=$(echo $currentDate-$tag)" >> $GITHUB_OUTPUT ;

--- a/format-version/action.yml
+++ b/format-version/action.yml
@@ -19,12 +19,12 @@ runs:
         
         IS_RELEASE_STYLE='${{ inputs.style-as-release }}'
         
+        dateVersion=currentDate=$(date +"%Y.%m.%d.%H.%M") ;
         if [ "$IS_RELEASE_STYLE" = "true" ] ; then
-          currentDate=$(date +"%Y.%m.%d.%H.%M") ;
-          tag=$(echo $GITHUB_SHA | cut -c 1-7) ;
+          tag="${dateVersion}" ;
           echo "version=$(echo $currentDate-$tag)" >> $GITHUB_OUTPUT ;
         else
           REF_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}
-          tag=$(echo ${REF_NAME} | cut -c 1-20 | tr / -)-SNAPSHOT ;
+          tag=$(echo ${REF_NAME} | cut -c 1-20 | tr / -)-SNAPSHOT-${dateVersion} ;
           echo "version=$(echo $tag)" >> $GITHUB_OUTPUT ;
         fi


### PR DESCRIPTION
Unique versions allow us to more easily update test environments. If version does not change the automation won't pull new image.