### PR TITLE
PLANFLEX-196 Add remote trigger for planning flexibility tests

### DIFF
--- a/planning-flexibility-tests/action.yml
+++ b/planning-flexibility-tests/action.yml
@@ -1,0 +1,49 @@
+name: 'Planning flexibility test'
+description: 'Run a system test in planning-flexibility-tests'
+inputs:
+  test-to-trigger:
+    description: 'Which test to trigger, e.g., system-activation'
+    required: true
+  service-name:
+    description: 'Name of the Docker image of the service to run the test for'
+    required: true
+  branch-name:
+    description: 'Name of the branch from where the test was triggered'
+    required: false
+  service-version:
+    description: 'Version of the Docker image of the service to run the test for'
+    required: true
+  comment-downstream-url:
+    description: 'Downstream url where to the trigger will add a comment with a link to the started workflow'
+    required: false
+  target-environment:
+    description: 'Which environment to take version for other services, i.e., staging or production'
+    required: false
+    default: 'staging'
+  secrets:
+    description: 'Secrets required for the build'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: tibdex/github-app-token@v2
+      id: generate-token
+      with:
+        app_id: ${{ fromJSON(inputs.secrets).TEST_TRIGGER_APP_ID }}
+        private_key: ${{ fromJSON(inputs.secrets).TEST_TRIGGER_APP_KEY }}
+
+    - uses: convictional/trigger-workflow-and-wait@v1.6.5
+      with:
+        owner: sympower
+        repo: planning-flexibility-tests
+        ref: main
+        workflow_file_name: remote-test-trigger.yml
+        client_payload: >-
+          { 
+            "origin": "${{ inputs.service-name }}:${{ inputs.branch-name }}", 
+            "origin-workflow" : "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "test-to-trigger": "${{ inputs.test-to-trigger }}", 
+            "target-environment": "${{ inputs.target-environment }}", 
+            "service-versions" : "{ \"${{ inputs.service-name }}\": \"${{ inputs.service-version }}\" }"
+          }
+        github_token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
# Description

As part of our (planetarians) work to split the activating and planning domains, we are going to also split the test suite.
This PR adds a new action to trigger the planning flexibility tests.
The action is a copy-paste of the activating-flexibility-tests trigger, with just the name changed.

## Type of change

- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Refactor
- [ ] Documentation update

## Checklist

- [ ] Any new code is covered with unit tests and/or integration tests
- [ ] Manual testing required: yes/no
  - Test plan: [link](https://www.notion.so/sympower)
  - Findings (including bugs/security problems that we are consciously releasing): [link](https://www.notion.so/sympower)